### PR TITLE
Adaptative time step

### DIFF
--- a/Main/plot.py
+++ b/Main/plot.py
@@ -10,32 +10,54 @@ import csv
 T = []
 d = []
 t = []
-d2 = []
-d3 = []
 
 with open('desorption1e22.csv', 'r') as csvfile:
     plots = csv.reader(csvfile, delimiter=',')
+    d1 = []
+    t1 = []
+    T1 = []
     for row in plots:
         if 'd' not in row and 'T' not in row and 't' not in row:
-            d.append(float(row[0]))
-            T.append(float(row[1]))
-            t.append(float(row[2]))
-
-with open('desorption.csv', 'r') as csvfile:
-    plots = csv.reader(csvfile, delimiter=',')
-    for row in plots:
-        if 'd' not in row and 'T' not in row and 't' not in row:
-            d2.append(float(row[0]))
+            d1.append(float(row[0]))
+            T1.append(float(row[1]))
+            t1.append(float(row[2]))
+    T.append(T1)
+    d.append(d1)
+    t.append(t1)
 
 with open('desorption1e23.csv', 'r') as csvfile:
     plots = csv.reader(csvfile, delimiter=',')
+    d1 = []
+    t1 = []
+    T1 = []
     for row in plots:
         if 'd' not in row and 'T' not in row and 't' not in row:
-            d3.append(float(row[0]))
+            d1.append(float(row[0]))
+            T1.append(float(row[1]))
+            t1.append(float(row[2]))
+    T.append(T1)
+    d.append(d1)
+    t.append(t1)
 
-plt.plot(T, d, label=r'fluence = $1\times 10^{22}$ D/m$ ^{2}$')
-plt.plot(T, d3, label=r'fluence = $1\times 10^{23}$ D/m$ ^{2}$')
-plt.plot(T, d2, label="desorption.csv")
+with open('desorption.csv', 'r') as csvfile:
+    plots = csv.reader(csvfile, delimiter=',')
+    d1 = []
+    t1 = []
+    T1 = []
+    for row in plots:
+        if 'd' not in row and 'T' not in row and 't' not in row:
+            d1.append(float(row[0]))
+            T1.append(float(row[1]))
+            t1.append(float(row[2]))
+    T.append(T1)
+    d.append(d1)
+    t.append(t1)
+
+
+
+plt.plot(T[0], d[0], label=r'fluence = $1\times 10^{22}$ D/m$ ^{2}$')
+plt.plot(T[1], d[1], label=r'fluence = $1\times 10^{23}$ D/m$ ^{2}$')
+plt.plot(T[2], d[2], label="desorption.csv")
 plt.xlabel('T(K)')
 plt.ylabel(r'desorption(D/m$ ^{2}$/s)')
 plt.title('TDS')


### PR DESCRIPTION
Added a function called `adapative_time_step` that changes the stepsize in order to optimise computation time. To avoid having too big time steps when temporal resolution is needed, the adaptative process can be stoped at `t_stop` with a maximum value for `dt `, `stepsize_stop_max`.
If the stepsize goes below `dt_min`, the calculation stops, thus avoiding infinite loops.

```
    def adaptative_timestep(self, converged, nb_it, dt, dt_min,
                            stepsize_change_ratio, t, t_stop,
                            stepsize_stop_max):
        '''
        Adapts the stepsize as function of the number of iterations of the
        solver.
        Arguments:
        - converged : bool, determines if the time step has converged.
        - nb_it : int, number of iterations
        - dt : Constant(), fenics object
        - dt_min : float, stepsize minimum value
        - stepsize_change_ration : float, stepsize change ratio
        - t : float, time
        - t_stop : float, time where adaptative time step stops
        - stepsize_stop_max : float, maximum stepsize after stop
        Returns:
        - dt : Constant(), fenics object
        '''
        while converged is False:
            dt.assign(float(dt)/stepsize_change_ratio)
            #print(float(dt))
            nb_it, converged = solver.solve()
            if float(dt) < dt_min:
                sys.exit('Error: stepsize reached minimal value')
        if t > t_stop:
            if float(dt) > stepsize_stop_max:
                dt.assign(stepsize_stop_max)

        else:
            if nb_it < 5:
                dt.assign(float(dt)*stepsize_change_ratio)
            else:
                dt.assign(float(dt)/stepsize_change_ratio)
        
        return dt
```